### PR TITLE
Process wait

### DIFF
--- a/cwt/process.py
+++ b/cwt/process.py
@@ -3,7 +3,8 @@ Process Module.
 """
 
 import json
-import logging
+import logging 
+import time
 
 import requests
 
@@ -228,6 +229,26 @@ class Process(cwt.Parameter):
 
         return 'No Status'
 
+    def wait(self):
+        status_hist = {}
+
+        def update_history(status):
+            if status not in status_hist:
+                status_hist[status] = True
+
+                logger.info('%s', status)
+
+        update_history(self.status)
+
+        while self.processing:
+            update_history(self.status)
+
+            time.sleep(1)
+
+        update_history(self.status)
+
+        return True if self.succeeded else False
+
     def validate(self):
         input_limit = None
 
@@ -366,9 +387,6 @@ class Process(cwt.Parameter):
         response = self.__client.http_request('GET', self.response.statusLocation, {}, {}, {})
 
         self.response = wps.CreateFromDocument(response)
-
-        if self.failed:
-            raise cwt.WPSError('Process failed: {}'.format(self.exception_message))
 
     def parameterize(self):
         """ Create a dictionary representation of the Process. """

--- a/cwt/tests/__init__.py
+++ b/cwt/tests/__init__.py
@@ -1,9 +1,0 @@
-#! /usr/bin/env python
-""" Testing module. """
-
-import os
-import unittest
-
-suite = unittest.TestLoader().discover(os.path.dirname(__file__))
-
-unittest.TextTestRunner(verbosity=2).run(suite)

--- a/cwt/tests/test_wps_client.py
+++ b/cwt/tests/test_wps_client.py
@@ -444,6 +444,31 @@ class TestWPSClient(unittest.TestCase):
         self.assertIsNotNone(process.response)
 
     @mock.patch('requests.Session.request') 
+    def test_execute_block(self, mock_request):
+        mock_request.return_value.status_code = 200
+
+        mock_request.return_value.text = self.execute.toxml(bds=cwt.bds)
+
+        client = cwt.WPSClient('http://idontexist/wps')
+
+        process = cwt.Process.from_identifier('CDAT.subset')
+
+        type(process).output = mock.PropertyMock(return_value='test output')
+
+        process.wait = mock.MagicMock()
+
+        process.description = mock.MagicMock()
+
+        result = client.execute(process, 
+                                [cwt.Variable('file:///test.nc', 'tas')],
+                                cwt.Domain([cwt.Dimension('time', 0, 365)]), 
+                                block=True)
+
+        process.wait.assert_called()
+
+        self.assertEqual(result, 'test output')
+
+    @mock.patch('requests.Session.request') 
     def test_execute(self, mock_request):
         mock_request.return_value.status_code = 200
 

--- a/cwt/wps_client.py
+++ b/cwt/wps_client.py
@@ -217,7 +217,8 @@ class WPSClient(object):
 
         return [x.description for x in process]
 
-    def execute(self, process, inputs=None, domain=None, method='POST', **kwargs):
+    def execute(self, process, inputs=None, domain=None, method='POST',
+                block=False, **kwargs):
         """ Execute the process on the WPS server. 
         
         Args:
@@ -261,8 +262,14 @@ class WPSClient(object):
 
         process.response = response
 
+        if block:
+            process.wait()
+
         if process.failed:
             raise Exception(process.exception_message)
+
+        if block:
+            return process.output
 
     def processes(self, pattern=None, method='GET'):
         if self.capabilities is None:


### PR DESCRIPTION
Adds method to the process class to allow waiting for completion of a process.
```python
client.execute(avg_process, inputs=[...])

avg_process.wait()
```
this basically just calls processing, prints current status and sleeps. It also prevents duplicate status messages from being printed.

Adds argument to the wps_client class's execute method to enable blocking. This defaults to false to maintain the current functionality. If block is set to true the output of execute is the output from the process.
```python
result = client.execute(avg_process, inputs=[...], block=True)

print result.uri
```