### PR TITLE
Fixes passing single value kwargs to add_parameter, adds unittesting …

### DIFF
--- a/cwt/process.py
+++ b/cwt/process.py
@@ -284,7 +284,7 @@ class Process(cwt.Parameter):
 
         for k, v in kwargs.iteritems():
             if not isinstance(v, (tuple, list)):
-                raise ProcessError('Invalid parameter argument type {}, should be a list or tuple', type(v))
+                v = [v]
 
             self.parameters[k] = cwt.NamedParameter(k, *v)
 

--- a/cwt/tests/__init__.py
+++ b/cwt/tests/__init__.py
@@ -1,9 +1,0 @@
-#! /usr/bin/env python
-""" Testing module. """
-
-import os
-import unittest
-
-suite = unittest.TestLoader().discover(os.path.dirname(__file__))
-
-unittest.TextTestRunner(verbosity=2).run(suite)

--- a/cwt/tests/test_process.py
+++ b/cwt/tests/test_process.py
@@ -117,18 +117,21 @@ class TestProcess(unittest.TestCase):
 
         self.assertEqual(len(process.inputs), 1)
 
+    def test_add_parameter_key_value_single(self):
+        process = cwt.Process.from_identifier('CDAT.subset')
+
+        process.add_parameters(test='value1')
+
+        self.assertEqual(len(process.parameters), 1)
+        self.assertEqual(process.parameters.values()[0].values, ['value1'])
+
     def test_add_parameter_key_value(self):
         process = cwt.Process.from_identifier('CDAT.subset')
 
         process.add_parameters(test=['value1'])
 
         self.assertEqual(len(process.parameters), 1)
-
-    def test_add_parameter_invalid_argument_type(self):
-        process = cwt.Process.from_identifier('CDAT.subset')
-
-        with self.assertRaises(cwt.ProcessError):
-            process.add_parameters(test='test')
+        self.assertEqual(process.parameters.values()[0].values, ['value1'])
         
     def test_add_parameter_invalid_type(self):
         process = cwt.Process.from_identifier('CDAT.subset')

--- a/cwt/tests/test_wps_client.py
+++ b/cwt/tests/test_wps_client.py
@@ -459,6 +459,32 @@ class TestWPSClient(unittest.TestCase):
 
         self.assertIsNotNone(process.response)
 
+    def test_prepare_data_inputs_parameters(self):
+        variable = cwt.Variable('file:///test.nc', 'tas', name='v0')
+
+        domain = cwt.Domain([
+            cwt.Dimension('time', 0, 365),
+        ], name='d0')
+
+        process = cwt.Process('CDAT.subset', name='subset')
+
+        process.description = mock.MagicMock()
+
+        process.description.metadata.return_value = {}
+
+        client = cwt.WPSClient('http://idontexist/wps')
+
+        data_inputs = client.prepare_data_inputs_str(process, [variable],
+                                                     domain, axes=['lats',
+                                                                   'lons'],
+                                                     weightoptions='generated',
+                                                    test=cwt.NamedParameter('test',
+                                                                           'True'))
+
+        expected = '[variable=[{"uri": "file:///test.nc", "id": "tas|v0"}];domain=[{"id": "d0", "time": {"start": 0, "step": 1, "end": 365, "crs": "values"}}];operation=[{"domain": "d0", "name": "CDAT.subset", "axes": "lats|lons", "result": "subset", "weightoptions": "generated", "test": "True", "input": ["v0"]}]]'
+
+        self.assertEqual(expected, data_inputs)
+
     def test_prepare_data_inputs(self):
         variable = cwt.Variable('file:///test.nc', 'tas', name='v0')
 


### PR DESCRIPTION
PR for #37.

Fixes passing single value to kwargs
```python
process.add_parameters(weightoptions='generated')
# use to be
process.add_parameters(weightoptions=['generated'])
```
Also adds testing to make sure calls to wps_client.execute work in the same manner.
```python
client.execute(process, weightoptions='generated')
```
