### PR TITLE
Update notebook for jenkins automated run

### DIFF
--- a/examples/aggregate.ipynb
+++ b/examples/aggregate.ipynb
@@ -53,7 +53,7 @@
     {
      "data": {
       "text/plain": [
-       "Process(identifier='CDAT.aggregate', title='CDAT.aggregate', status_supported=None, store_supported=None, process_version='devel', abstract='Aggregate a variable over multiple files. Supports subsetting and regridding.', metadata=[{'url': None, 'title': 'inputs:50', 'role': None}])"
+       "Process(identifier='CDAT.aggregate', title='CDAT.aggregate', status_supported=None, store_supported=None, process_version='devel', abstract='Aggregates multiple files over a temporal axis.', metadata=[{'url': None, 'title': 'inputs:1', 'role': None}])"
       ]
      },
      "execution_count": 3,
@@ -76,7 +76,8 @@
      "output_type": "stream",
      "text": [
       "ProcessAccepted None\n",
-      "ProcessStarted Building aggregation with 3 inputs 0\n",
+      "ProcessStarted None 0\n",
+      "ProcessStarted Preparing to execute 0\n",
       "ProcessStarted Processing 0\n",
       "ProcessSucceeded None\n"
      ]

--- a/examples/aggregate_regrid.ipynb
+++ b/examples/aggregate_regrid.ipynb
@@ -13,22 +13,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "WPSClient(url='https://aims2.llnl.gov/wps/', log=False, log_file=None, verify=True, version=None, cert=None, headers={})"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "host = 'aims2.llnl.gov'\n",
     "verify = True\n",

--- a/examples/aggregate_regrid.ipynb
+++ b/examples/aggregate_regrid.ipynb
@@ -80,6 +80,7 @@
      "output_type": "stream",
      "text": [
       "ProcessAccepted None\n",
+      "ProcessStarted None 0\n",
       "ProcessStarted Processing 0\n",
       "ProcessSucceeded None\n"
      ]

--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -78,20 +78,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "WPSClient(url='https://aims2.llnl.gov/wps/', log=False, log_file=None, verify=True, version=None, cert=None, headers={'COMPUTE-TOKEN': 'lh9us2QVfzJmRpKAzROZVbzfYOV4GNl4gIW4inTX9mlRInFOfysRwa9865Zujgzv'})"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "host = 'aims2.llnl.gov'\n",
     "verify = True\n",
@@ -386,7 +375,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -109,22 +109,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CDAT.metrics\n",
-      "CDAT.workflow\n",
-      "CDAT.subset\n",
+      "CDAT.abs\n",
+      "CDAT.add\n",
       "CDAT.aggregate\n",
-      "CDAT.regrid\n",
-      "CDAT.sum\n",
+      "CDAT.average\n",
+      "CDAT.divide\n",
+      "CDAT.log\n",
       "CDAT.max\n",
+      "CDAT.metrics\n",
       "CDAT.min\n",
+      "CDAT.multiply\n",
+      "CDAT.power\n",
+      "CDAT.regrid\n",
+      "CDAT.subset\n",
       "CDAT.subtract\n",
-      "CDAT.add\n"
+      "CDAT.sum\n",
+      "CDAT.workflow\n"
      ]
     }
    ],
    "source": [
-    "for p in client.processes():\n",
-    "    print(p.identifier)"
+    "process_ids = [p.identifier for p in client.processes()]\n",
+    "process_ids.sort()\n",
+    "for process_id in process_ids:\n",
+    "    print(process_id)"
    ]
   },
   {
@@ -175,7 +183,7 @@
     {
      "data": {
       "text/plain": [
-       "Process(identifier='CDAT.subset', title='CDAT.subset', status_supported=None, store_supported=None, process_version='devel', abstract='Subset a variable by provided domain. Supports regridding.', metadata=[{'url': None, 'title': 'inputs:1', 'role': None}])"
+       "Process(identifier='CDAT.subset', title='CDAT.subset', status_supported=None, store_supported=None, process_version='devel', abstract='Subsets an input to desired domain.', metadata=[{'url': None, 'title': 'inputs:1', 'role': None}])"
       ]
      },
      "execution_count": 4,


### PR DESCRIPTION
At Ouranos, we have a Jenkins job (https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/blob/enable-esgf-notebooks-in-jenkins/Jenkinsfile) that can run all the ESGF notebooks to detect failure or differences in output.

I started to fix a few of the errors, see each commit comment for the error I tried to fix.

I am not done yet but I think for the long run it would be better that you can run Jenkins test suite and fix the errors yourself.

The instructions to run the test suite yourself can be found at the same repo (https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests#run-locally).  Alternatively you can run the entire Jenkins preconfigured with the test suite (probably even easier) by following https://github.com/Ouranosinc/jenkins-config.

There is also this kind of error, only happen in Jenkins, `StdinNotImplementedError: raw_input was called, but this frontend does not support input requests.` that I do not have an idea how to fix yet.  Running manually interactively works fine.
```
13:10:31  ___________ esgf-compute-api-devel/examples/aggregate.ipynb::Cell 4 ____________
13:10:31  Notebook cell execution failed
13:10:31  Cell 4: Cell execution caused an exception
[2019-11-23T18:10:31.559Z] 
[2019-11-23T18:10:31.559Z] Input:
[2019-11-23T18:10:31.559Z] import cdms2
13:10:31  
13:10:31  f = cdms2.open(proc.output.uri)
13:10:31  
13:10:31  tas = f[proc.output.var_name]
13:10:31  
13:10:31  # (362, 240, 480)
13:10:31  print(tas.shape)
13:10:31  
13:10:31  Traceback:
13:10:31  
13:10:31  ---------------------------------------------------------------------------
13:10:31  StdinNotImplementedError                  Traceback (most recent call last)
13:10:31  <ipython-input-5-a1bcbd5a8932> in <module>
13:10:31  ----> 1 import cdms2
13:10:31        2 
13:10:31        3 f = cdms2.open(proc.output.uri)
13:10:31        4 
13:10:31        5 tas = f[proc.output.var_name]
13:10:31  
13:10:31  /usr/local/envs/birdy/lib/python3.7/site-packages/cdms2/__init__.py in <module>
13:10:31       23 
13:10:31       24 import cdat_info
13:10:31  ---> 25 cdat_info.pingPCMDIdb("cdat", "cdms2")  # noqa
13:10:31       26 #
13:10:31       27 __all__ = ["cdmsobj", "axis", "coord", "grid", "hgrid", "avariable",
13:10:31  
13:10:31  /usr/local/envs/birdy/lib/python3.7/site-packages/cdat_info-8.1-py2.7.egg/cdat_info/cdat_info_src.py in pingPCMDIdb(*args, **kargs)
13:10:31      219     except BaseException:
13:10:31      220         pass
13:10:31  --> 221     askAnonymous(val)
13:10:31      222     # Ping db only if we never did this yet!
13:10:31      223     if not args in posted:
13:10:31  
13:10:31  /usr/local/envs/birdy/lib/python3.7/site-packages/cdat_info-8.1-py2.7.egg/cdat_info/cdat_info_src.py in askAnonymous(val)
13:10:31      181     while cdat_info.ping_checked is False and val not in [True, False]:
13:10:31      182         val2 = input(
13:10:31  --> 183             "Allow anonymous logging usage to help improve CDAT" +
13:10:31      184             "(you can also set the environment variable CDAT_ANONYMOUS_LOG to yes or no)? [yes]/no: ")
13:10:31      185         if val2.lower() in ['y', 'yes', 'ok', '1', 'true', '']:
13:10:31  
13:10:31  /usr/local/envs/birdy/lib/python3.7/site-packages/ipykernel/kernelbase.py in raw_input(self, prompt)
13:10:31      852         if not self._allow_stdin:
13:10:31      853             raise StdinNotImplementedError(
13:10:31  --> 854                 "raw_input was called, but this frontend does not support input requests."
13:10:31      855             )
13:10:31      856         return self._input_request(str(prompt),
13:10:31  
13:10:31  StdinNotImplementedError: raw_input was called, but this frontend does not support input requests.
```

So this PR can give you an idea of the kind of fixes required.  Most is to match the output of updated code or updated runtime environment.  That `StdinNotImplementedError` above will be tricky to fix.

If you have any questions about launching the Jenkins instance, just let me know.

